### PR TITLE
Deposit API Change

### DIFF
--- a/src/Deposit.yulp
+++ b/src/Deposit.yulp
@@ -19,18 +19,18 @@ object "Deposit" is "Storage", "Tokens", "FunnelFactory" {
 
     /// @notice Get deposit at key
     /// @return Amount of tokens as uint256
-    function depositAt(account, token, blockNumber) -> amount {
-      amount := sload(mappingKey3(Storage.Deposits, account, token, blockNumber))
+    function depositAt(owner, token, blockNumber) -> amount {
+      amount := sload(mappingKey3(Storage.Deposits, owner, token, blockNumber))
     }
 
     /// @notice Handle token deposit.
-    function deposit(account, token) {
+    function deposit(owner, token) {
       // Get token ID (0 for ETH).
       // If token has not yet been deposited, a new token ID will be assigned.
       let _tokenId := commitToken(token)
 
       // Build create2 deposit funnel contract
-      let funnel := createFunnel(account)
+      let funnel := createFunnel(owner)
 
       // Variables
       let amount := 0
@@ -64,15 +64,15 @@ object "Deposit" is "Storage", "Tokens", "FunnelFactory" {
       }
 
       // Load current balance from storage
-      // Deposits are uniquely identified by account, token, and Ethereum block numbers, so a second deposit in the same block will simply update a single deposit object
-      let balanceAmount := depositAt(account, _tokenId, number())
-      sstore(mappingKey3(Storage.Deposits, account, _tokenId, number()), add(balanceAmount, amount))
+      // Deposits are uniquely identified by owner, token, and Ethereum block numbers, so a second deposit in the same block will simply update a single deposit object
+      let balanceAmount := depositAt(owner, _tokenId, number())
+      sstore(mappingKey3(Storage.Deposits, owner, _tokenId, number()), add(balanceAmount, amount))
 
       mstore(0, amount)
       log3(0, mul32(1),
-        topic"event DepositMade(address indexed account, address indexed token, uint256 amount)",
-        account,
-        token)
+        topic"event DepositMade(address indexed owner, uint32 indexed token, uint256 value)",
+        owner,
+        _tokenId)
     }
   }
 }

--- a/src/tests/deposit.js
+++ b/src/tests/deposit.js
@@ -49,9 +49,9 @@ module.exports = test('deposit', async t => { try {
     await t.balanceEqual(contract.address, valuea, 'value');
     t.equal(etx.events.length, 1, 'len events');
     t.equal(etx.events[0].event, 'DepositMade', 'event');
-    t.equal(etx.events[0].args.account, producer, 'account');
-    t.equal(etx.events[0].args.token, utils.emptyAddress, 'token');
-    t.equalBig(etx.events[0].args.amount, valuea, 'amount');
+    t.equal(etx.events[0].args.owner, producer, 'account');
+    t.equalBig(etx.events[0].args.token, 0, 'token');
+    t.equalBig(etx.events[0].args.value, valuea, 'value');
 
 
 
@@ -79,9 +79,9 @@ module.exports = test('deposit', async t => { try {
     t.equal(ttx.events[0].args.token, token.address, 'token');
 
     t.equal(ttx.events[2].event, 'DepositMade', 'event');
-    t.equal(ttx.events[2].args.account, producer, 'account');
-    t.equal(ttx.events[2].args.token, token.address, 'token');
-    t.equalBig(ttx.events[2].args.amount, tokenValue, 'amount');
+    t.equal(ttx.events[2].args.owner, producer, 'account');
+    t.equalBig(ttx.events[2].args.token, 1, 'token');
+    t.equalBig(ttx.events[2].args.value, tokenValue, 'amount');
 
     await t.revert(contract.deposit(producer, utils.emptyAddress, overrides),
       errors['value-underflow'], 'value underflow', errors);


### PR DESCRIPTION
### Changes
- Deposit event name changes as to fit into existing proofing structures, constantly
- `account` -> `owner`
- `amount` -> `value`
- token is now the token Id for consistency and so that it can be reduced to mapped deposit in client etc..

Just need final review before merge, all tests pass on my end.