### PR TITLE
Update All `struct`'s to new API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -88,12 +88,50 @@
       }
     },
     "@fuel-js/protocol": {
-      "version": "0.0.9",
-      "resolved": "https://registry.npmjs.org/@fuel-js/protocol/-/protocol-0.0.9.tgz",
-      "integrity": "sha512-Z8ZtmwJeQfmceH/bYXk87xV3cnK2x1CrpnJBnfb3HSKZ2tVvhTf2lKW2fyKHFlDAGOuWReo9jHM21vqzuefZWA==",
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/@fuel-js/protocol/-/protocol-0.1.7.tgz",
+      "integrity": "sha512-MiYQK3+7m3X7ohNFEosjWjLTggIozo0atySjLE2/obpLxeaT7SDy9avt7X3ZHI+y8QiX58R4hGmFfZeXiEMTXg==",
       "dev": true,
       "requires": {
-        "@fuel-js/common": "^0.0.6"
+        "@fuel-js/struct": "^0.1.1",
+        "@fuel-js/utils": "^0.1.0"
+      }
+    },
+    "@fuel-js/rolled": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@fuel-js/rolled/-/rolled-0.1.0.tgz",
+      "integrity": "sha512-hkp/gJMxpmA/3jiiU6TXBdPjEGTexkoyOEgQ2v6knB9ioAQKWyFeD2umwfvRf3946rQLcOzQOc5/Wjmbc6c42A==",
+      "dev": true,
+      "requires": {
+        "@fuel-js/utils": "^0.1.0"
+      }
+    },
+    "@fuel-js/struct": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@fuel-js/struct/-/struct-0.1.1.tgz",
+      "integrity": "sha512-fkfr2I6BBNvDOHQfGzp0SPvN3yXFW5vyTcEvgYrlBGvAEk+KaRabMTkCzHQa9gThHzbVhBhhifDkMuJuYtHPfA==",
+      "dev": true,
+      "requires": {
+        "@fuel-js/rolled": "^0.1.0",
+        "@fuel-js/utils": "^0.1.0"
+      }
+    },
+    "@fuel-js/utils": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@fuel-js/utils/-/utils-0.1.0.tgz",
+      "integrity": "sha512-6cQ27SXYhVcwN0qwqZZYQETXxv57Y+6/RI2sGSUxF96ZUlS6PfG2vWV4+DvE6S8VZhUsRTjRGNvxtOJHKRyf5w==",
+      "dev": true,
+      "requires": {
+        "bn.js": "^5.1.1",
+        "ethers": "^4.0.47"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.1.2.tgz",
+          "integrity": "sha512-40rZaf3bUNKTVYu9sIeeEGOg7g14Yvnj9kH7b50EiwX0Q7A6umbvfI5tvHaOERH0XigqKkfLkFQxzb4e6CIXnA==",
+          "dev": true
+        }
       }
     },
     "@hyperapp/router": {

--- a/package.json
+++ b/package.json
@@ -39,9 +39,10 @@
   },
   "homepage": "https://github.com/fuellabs/fuel#readme",
   "devDependencies": {
-    "ethers": "^4.0.47",
     "@fuel-js/common": "^0.0.6",
     "@fuel-js/environment": "0.0.8",
-    "@fuel-js/protocol": "^0.0.9"
+    "@fuel-js/protocol": "^0.1.7",
+    "@fuel-js/struct": "^0.1.1",
+    "ethers": "^4.0.47"
   }
 }

--- a/src/benchmarks/burning.js
+++ b/src/benchmarks/burning.js
@@ -1,7 +1,7 @@
 // 75,000 one-off points burning
 
 const { test, utils, overrides } = require('@fuel-js/environment');
-const { chunk, pack, combine } = require('@fuel-js/common/struct');
+const { chunk, pack, combine } = require('@fuel-js/struct');
 const { bytecode, abi, errors } = require('../builds/Fuel.json');
 const Proxy = require('../builds/Proxy.json');
 const ERC20 = require('../builds/ERC20.json');
@@ -74,7 +74,7 @@ module.exports = test('75k Burn Transactions', async t => { try {
       feeToken: tokenId,
     }));
     rootHashes.push(root.keccak256Packed());
-    let rootTx = await contract.commitRoot(root.properties.merkleTreeRoot.get(), tokenId, chunk, combine(txs), overrides);
+    let rootTx = await contract.commitRoot(root.properties.merkleTreeRoot().get(), tokenId, chunk, combine(txs), overrides);
     rootTx = await rootTx.wait();
     rootsCommitted += 1;
     cumulativeGasUsed = cumulativeGasUsed.add(rootTx.cumulativeGasUsed);

--- a/src/benchmarks/minting.js
+++ b/src/benchmarks/minting.js
@@ -1,7 +1,7 @@
 // 100k Points Claims One-off points burning
 
 const { test, utils, overrides } = require('@fuel-js/environment');
-const { chunk, pack, combine } = require('@fuel-js/common/struct');
+const { chunk, pack, combine } = require('@fuel-js/struct');
 const { bytecode, abi, errors } = require('../builds/Fuel.json');
 const Proxy = require('../builds/Proxy.json');
 const ERC20 = require('../builds/ERC20.json');
@@ -97,7 +97,7 @@ module.exports = test('100k Points Claims', async t => { try {
       feeToken: tokenId,
     }));
     rootHashes.push(root.keccak256Packed());
-    let rootTx = await contract.commitRoot(root.properties.merkleTreeRoot.get(), tokenId, chunk, combine(txs), overrides);
+    let rootTx = await contract.commitRoot(root.properties.merkleTreeRoot().get(), tokenId, chunk, combine(txs), overrides);
     rootTx = await rootTx.wait();
     rootsCommitted += 1;
     cumulativeGasUsed = cumulativeGasUsed.add(rootTx.cumulativeGasUsed);

--- a/src/benchmarks/subscriptions.js
+++ b/src/benchmarks/subscriptions.js
@@ -1,7 +1,7 @@
 // 25,000 subscription transactions
 
 const { test, utils, overrides } = require('@fuel-js/environment');
-const { chunk, pack, combine } = require('@fuel-js/common/struct');
+const { chunk, pack, combine } = require('@fuel-js/struct');
 const { bytecode, abi, errors } = require('../builds/Fuel.json');
 const Proxy = require('../builds/Proxy.json');
 const ERC20 = require('../builds/ERC20.json');
@@ -72,7 +72,7 @@ module.exports = test('25k Subscription Transactions', async t => { try {
       feeToken: tokenId,
     }));
     rootHashes.push(root.keccak256Packed());
-    let rootTx = await contract.commitRoot(root.properties.merkleTreeRoot.get(), tokenId, chunk, combine(txs), overrides);
+    let rootTx = await contract.commitRoot(root.properties.merkleTreeRoot().get(), tokenId, chunk, combine(txs), overrides);
     rootTx = await rootTx.wait();
     rootsCommitted += 1;
     cumulativeGasUsed = cumulativeGasUsed.add(rootTx.cumulativeGasUsed);

--- a/src/benchmarks/transactions.js
+++ b/src/benchmarks/transactions.js
@@ -1,7 +1,7 @@
 // 100,000 transfers
 
 const { test, utils, overrides } = require('@fuel-js/environment');
-const { chunk, pack, combine } = require('@fuel-js/common/struct');
+const { chunk, pack, combine } = require('@fuel-js/struct');
 const { bytecode, abi, errors } = require('../builds/Fuel.json');
 const Proxy = require('../builds/Proxy.json');
 const ERC20 = require('../builds/ERC20.json');
@@ -72,7 +72,7 @@ module.exports = test('100k transactions', async t => { try {
       feeToken: tokenId,
     }));
     rootHashes.push(root.keccak256Packed());
-    let rootTx = await contract.commitRoot(root.properties.merkleTreeRoot.get(), tokenId, chunk, combine(txs), overrides);
+    let rootTx = await contract.commitRoot(root.properties.merkleTreeRoot().get(), tokenId, chunk, combine(txs), overrides);
     rootTx = await rootTx.wait();
     rootsCommitted += 1;
 

--- a/src/tests/bondWithdraw.js
+++ b/src/tests/bondWithdraw.js
@@ -43,7 +43,7 @@ module.exports = test('bondWithdraw', async t => { try {
       ...overrides,
       value: await contract.BOND_SIZE(),
     }), 'commit block', errors);
-    header.properties.ethereumBlockNumber.set(ctx.events[0].blockNumber);
+    header.properties.blockNumber().set(ctx.events[0].blockNumber);
     t.equalBig(await contract.blockTip(), 1, 'tip');
 
 
@@ -72,7 +72,7 @@ module.exports = test('bondWithdraw', async t => { try {
     t.equalBig(bwtx.events[0].args.owner, producer, 'owner');
     t.equalBig(bwtx.events[0].args.tokenAddress, 0, 'tokenAddress');
     t.equalBig(bwtx.events[0].args.amount, await contract.BOND_SIZE(), 'amount');
-    t.equalBig(bwtx.events[0].args.blockHeight, header.properties.height.get(),
+    t.equalBig(bwtx.events[0].args.blockHeight, header.properties.height().get(),
       'blockHeight');
     t.equalBig(bwtx.events[0].args.rootIndex, 0, 'rootIndex');
     t.equalBig(bwtx.events[0].args.transactionLeafHash, 0, 'transactionLeafHash');

--- a/src/tests/commitBlock.js
+++ b/src/tests/commitBlock.js
@@ -47,7 +47,7 @@ module.exports = test('commitBlock', async t => { try {
       ...overrides,
       value: await contract.BOND_SIZE(),
     }), 'commit block', errors);
-    header.properties.ethereumBlockNumber.set(ctx.events[0].blockNumber);
+    header.properties.blockNumber().set(ctx.events[0].blockNumber);
     t.equalBig(await contract.blockTip(), 1, 'tip');
 
     t.equal(ctx.logs.length, 1, 'length');
@@ -171,7 +171,7 @@ module.exports = test('commitBlock', async t => { try {
 
 
 
-    header.properties.ethereumBlockNumber.set(ctx.events[0].blockNumber);
+    header.properties.blockNumber().set(ctx.events[0].blockNumber);
     const header2 = (new BlockHeader({
       producer,
       height: 2,
@@ -218,7 +218,7 @@ module.exports = test('commitBlock', async t => { try {
 
     // valid commit block from other non producer user
     await t.increaseBlock(await other.SUBMISSION_DELAY());
-    header2.properties.ethereumBlockNumber.set(cvtx.events[0].blockNumber);
+    header2.properties.blockNumber().set(cvtx.events[0].blockNumber);
     const header3 = (new BlockHeader({
       producer: producerB,
       height: 3,

--- a/src/tests/harness.js
+++ b/src/tests/harness.js
@@ -1,5 +1,5 @@
 const { test, utils, overrides } = require('@fuel-js/environment');
-const { chunk, pack, combine } = require('@fuel-js/common/struct');
+const { chunk, pack, combine } = require('@fuel-js/struct');
 const { bytecode, abi, errors } = require('../builds/Fuel.json');
 const Proxy = require('../builds/Proxy.json');
 const ERC20 = require('../builds/ERC20.json');

--- a/src/tests/ownedProxy.js
+++ b/src/tests/ownedProxy.js
@@ -80,6 +80,6 @@ module.exports = test('owned proxy', async t => {
   const ctx = await t.wait(proxy.transact(contract.address, await contract.BOND_SIZE(), abiCode, overrides),
     'transact commitBlock', OwnedProxy.errors);
 
-  header.properties.ethereumBlockNumber.set(ctx.events[0].blockNumber);
+  header.properties.blockNumber().set(ctx.events[0].blockNumber);
   t.equalBig(await contract.blockTip(), 1, 'tip');
 });

--- a/src/tests/proveDoubleSpend.js
+++ b/src/tests/proveDoubleSpend.js
@@ -1,5 +1,5 @@
 const { test, utils, overrides } = require('@fuel-js/environment');
-const { chunk, pack, combine } = require('@fuel-js/common/struct');
+const { chunk, pack, combine } = require('@fuel-js/struct');
 const { bytecode, abi, errors } = require('../builds/Fuel.json');
 const Proxy = require('../builds/Proxy.json');
 const ERC20 = require('../builds/ERC20.json');
@@ -98,7 +98,7 @@ module.exports = test('proveDoubleSpend', async t => { try {
       commitmentHash: utils.keccak256(combine(txs)),
       rootLength: utils.hexDataLength(combine(txs)),
     }));
-    await t.wait(contract.commitRoot(root.properties.merkleTreeRoot.get(), 0, 0, combine(txs), overrides),
+    await t.wait(contract.commitRoot(root.properties.merkleTreeRoot().get(), 0, 0, combine(txs), overrides),
       'valid submit', errors);
     const header = (new BlockHeader({
       producer,
@@ -114,7 +114,7 @@ module.exports = test('proveDoubleSpend', async t => { try {
       ...overrides,
       value: await contract.BOND_SIZE(),
     }), 'commit block', errors);
-    header.properties.ethereumBlockNumber.set(block.events[0].blockNumber);
+    header.properties.blockNumber().set(block.events[0].blockNumber);
     t.equalBig(await contract.blockTip(), 1, 'tip');
 
     // submit a withdrawal proof

--- a/src/tests/proveInvalidInput.js
+++ b/src/tests/proveInvalidInput.js
@@ -1,5 +1,5 @@
 const { test, utils, overrides } = require('@fuel-js/environment');
-const { chunk, pack, combine } = require('@fuel-js/common/struct');
+const { chunk, pack, combine } = require('@fuel-js/struct');
 const { bytecode, abi, errors } = require('../builds/Fuel.json');
 const Proxy = require('../builds/Proxy.json');
 const ERC20 = require('../builds/ERC20.json');
@@ -271,7 +271,7 @@ module.exports = test('proveInvalidInput', async t => { try {
       commitmentHash: utils.keccak256(combine(txs)),
       rootLength: utils.hexDataLength(combine(txs)),
     }));
-    await t.wait(contract.commitRoot(root.properties.merkleTreeRoot.get(), 0, 0, combine(txs), overrides),
+    await t.wait(contract.commitRoot(root.properties.merkleTreeRoot().get(), 0, 0, combine(txs), overrides),
       'valid submit', errors);
 
     const root2 = (new RootHeader({
@@ -281,7 +281,7 @@ module.exports = test('proveInvalidInput', async t => { try {
       rootLength: utils.hexDataLength(combine(txs)),
       fee: 500,
     }));
-    await t.wait(contract.commitRoot(root.properties.merkleTreeRoot.get(), 0, 500, combine(txs), overrides),
+    await t.wait(contract.commitRoot(root.properties.merkleTreeRoot().get(), 0, 500, combine(txs), overrides),
       'valid submit', errors);
 
     const header = (new BlockHeader({
@@ -298,7 +298,7 @@ module.exports = test('proveInvalidInput', async t => { try {
       ...overrides,
       value: await contract.BOND_SIZE(),
     }), 'commit block', errors);
-    header.properties.ethereumBlockNumber.set(block.events[0].blockNumber);
+    header.properties.blockNumber().set(block.events[0].blockNumber);
     t.equalBig(await contract.blockTip(), 1, 'tip');
 
     if (opts.fraud === 'input-transaction-index-overflow') {

--- a/src/tests/proveInvalidSum.js
+++ b/src/tests/proveInvalidSum.js
@@ -1,5 +1,5 @@
 const { test, utils, overrides } = require('@fuel-js/environment');
-const { chunk, pack, combine, chunkJoin } = require('@fuel-js/common/struct');
+const { chunk, pack, combine, chunkJoin } = require('@fuel-js/struct');
 const { bytecode, abi, errors } = require('../builds/Fuel.json');
 const Proxy = require('../builds/Proxy.json');
 const ERC20 = require('../builds/ERC20.json');
@@ -113,7 +113,7 @@ module.exports = test('proveInvalidSum', async t => { try {
       feeToken: tokenId,
       fee,
     }));
-    await t.wait(contract.commitRoot(root.properties.merkleTreeRoot.get(), tokenId, fee,
+    await t.wait(contract.commitRoot(root.properties.merkleTreeRoot().get(), tokenId, fee,
       combine(txs), overrides),
       'valid submit', errors);
     const header = new BlockHeader({
@@ -130,7 +130,7 @@ module.exports = test('proveInvalidSum', async t => { try {
       ...overrides,
       value: await contract.BOND_SIZE(),
     }), 'commit block', errors);
-    header.properties.ethereumBlockNumber.set(block.events[0].blockNumber);
+    header.properties.blockNumber().set(block.events[0].blockNumber);
     t.equalBig(await contract.blockTip(), 1, 'tip');
 
     // submit a withdrawal proof

--- a/src/tests/proveInvalidTransaction.js
+++ b/src/tests/proveInvalidTransaction.js
@@ -1,5 +1,5 @@
 const { test, utils, overrides } = require('@fuel-js/environment');
-const { chunk, pack, combine } = require('@fuel-js/common/struct');
+const { chunk, pack, combine } = require('@fuel-js/struct');
 const { bytecode, abi, errors } = require('../builds/Fuel.json');
 const Proxy = require('../builds/Proxy.json');
 const ERC20 = require('../builds/ERC20.json');
@@ -165,7 +165,7 @@ module.exports = test('proveInvalidTransaction', async t => { try {
         owner: producer,
         blockNumber: '0x00',
       });
-      invalidWitness.properties.type.set('0x03');
+      invalidWitness.properties.type().set('0x03');
       witnesses = [invalidWitness];
     }
 
@@ -174,7 +174,7 @@ module.exports = test('proveInvalidTransaction', async t => { try {
         owner: producer,
         blockNumber: '0x00',
       })];
-      witnesses[0].properties.type.set('0x00');
+      witnesses[0].properties.type().set('0x00');
     }
 
     if (opts.fraud === 'witnesses-index-overflow') {
@@ -191,7 +191,7 @@ module.exports = test('proveInvalidTransaction', async t => { try {
 
     if (opts.fraud === 'inputs-type-overflow') {
       const invalidInput = tx.Input({});
-      invalidInput.properties.type.set('0x05');
+      invalidInput.properties.type().set('0x05');
       inputs = [invalidInput];
     }
 
@@ -206,7 +206,7 @@ module.exports = test('proveInvalidTransaction', async t => { try {
 
     if (opts.fraud === 'inputs-size') {
       const invalidInput = tx.Input({});
-      invalidInput.properties.type.set('0x01');
+      invalidInput.properties.type().set('0x01');
       inputs = [invalidInput];
     }
 
@@ -262,8 +262,8 @@ module.exports = test('proveInvalidTransaction', async t => { try {
         amount: 0,
         owner: producer,
       });
-      invalidOutput.properties.shift.set(1);
-      invalidOutput.properties.amount.set([]);
+      invalidOutput.properties.shift().set(1);
+      invalidOutput.properties.amount().set([]);
       outputs = [invalidOutput];
     }
 
@@ -273,8 +273,8 @@ module.exports = test('proveInvalidTransaction', async t => { try {
         amount: 0,
         owner: producer,
       });
-      invalidOutput.properties.shift.set(1);
-      invalidOutput.properties.amount.set(utils.emptyBytes32);
+      invalidOutput.properties.shift().set(1);
+      invalidOutput.properties.amount().set(utils.emptyBytes32);
       outputs = [invalidOutput];
     }
 
@@ -284,8 +284,8 @@ module.exports = test('proveInvalidTransaction', async t => { try {
         amount: 0,
         owner: producer,
       });
-      invalidOutput.properties.shift.set(8);
-      invalidOutput.properties.amount.set(utils.emptyBytes32 + '00');
+      invalidOutput.properties.shift().set(8);
+      invalidOutput.properties.amount().set(utils.emptyBytes32 + '00');
       outputs = [invalidOutput];
     }
 
@@ -295,8 +295,8 @@ module.exports = test('proveInvalidTransaction', async t => { try {
         amount: 45,
         owner: producer,
       });
-      invalidOutput.properties.shift.set(8);
-      invalidOutput.properties.amount.set(utils.emptyBytes32);
+      invalidOutput.properties.shift().set(8);
+      invalidOutput.properties.amount().set(utils.emptyBytes32);
       outputs = [invalidOutput];
     }
 
@@ -376,7 +376,7 @@ module.exports = test('proveInvalidTransaction', async t => { try {
 
     if (opts.fraud === 'outputs-type') {
       const invalidOutput = tx.OutputTransfer({});
-      invalidOutput.properties.type.set('0x05');
+      invalidOutput.properties.type().set('0x05');
       outputs = [invalidOutput];
     }
 
@@ -392,7 +392,7 @@ module.exports = test('proveInvalidTransaction', async t => { try {
     });
 
     if (opts.fraud === 'transaction-length') {
-      transaction.properties.length.set(45);
+      transaction.properties.length().set(45);
     }
 
     // produce it in a block
@@ -403,7 +403,7 @@ module.exports = test('proveInvalidTransaction', async t => { try {
       commitmentHash: utils.keccak256(combine(txs)),
       rootLength: utils.hexDataLength(combine(txs)),
     }));
-    await t.wait(contract.commitRoot(root.properties.merkleTreeRoot.get(), 0, 0, combine(txs), overrides),
+    await t.wait(contract.commitRoot(root.properties.merkleTreeRoot().get(), 0, 0, combine(txs), overrides),
       'valid submit', errors);
     const header = (new BlockHeader({
       producer,
@@ -419,7 +419,7 @@ module.exports = test('proveInvalidTransaction', async t => { try {
       ...overrides,
       value: await contract.BOND_SIZE(),
     }), 'commit block', errors);
-    header.properties.ethereumBlockNumber.set(block.events[0].blockNumber);
+    header.properties.blockNumber().set(block.events[0].blockNumber);
     t.equalBig(await contract.blockTip(), 1, 'tip');
 
 

--- a/src/tests/proveInvalidWitness.js
+++ b/src/tests/proveInvalidWitness.js
@@ -1,5 +1,5 @@
 const {test, utils, overrides} = require('@fuel-js/environment');
-const {chunk, pack, combine} = require('@fuel-js/common/struct');
+const {chunk, pack, combine} = require('@fuel-js/struct');
 const {bytecode, abi, errors} = require('../builds/Fuel.json');
 const Proxy = require('../builds/Proxy.json');
 const ERC20 = require('../builds/ERC20.json');
@@ -156,7 +156,7 @@ module.exports = test('proveInvalidWitness', async t => {
         })];
         txMetadata = [tx.MetadataDeposit({
           token: tokenId,
-          blockNumber: deposit.properties.blockNumber.get(),
+          blockNumber: deposit.properties.blockNumber().get(),
         })];
         data = [deposit.keccak256()];
         inputs = deposit.encode();
@@ -169,7 +169,7 @@ module.exports = test('proveInvalidWitness', async t => {
         })];
         txMetadata = [tx.MetadataDeposit({
           token: '0x02',
-          blockNumber: deposit.properties.blockNumber.get(),
+          blockNumber: deposit.properties.blockNumber().get(),
         })];
         data = [deposit.keccak256()];
         inputs = deposit.encode();
@@ -196,7 +196,7 @@ module.exports = test('proveInvalidWitness', async t => {
         })];
         txMetadata = [tx.MetadataDeposit({
           token: tokenId,
-          blockNumber: deposit.properties.blockNumber.get(),
+          blockNumber: deposit.properties.blockNumber().get(),
         })];
         data = [utils.emptyBytes32];
         inputs = deposit.encode();
@@ -282,7 +282,7 @@ module.exports = test('proveInvalidWitness', async t => {
       }));
       await t.wait(
           contract.commitRoot(
-              root.properties.merkleTreeRoot.get(), 0, 0, combine(txs),
+              root.properties.merkleTreeRoot().get(), 0, 0, combine(txs),
               overrides),
           'valid submit', errors);
       const header = (new BlockHeader({
@@ -301,7 +301,7 @@ module.exports = test('proveInvalidWitness', async t => {
             value: await contract.BOND_SIZE(),
           }),
           'commit block', errors);
-      header.properties.ethereumBlockNumber.set(block.events[0].blockNumber);
+      header.properties.blockNumber().set(block.events[0].blockNumber);
       t.equalBig(await contract.blockTip(), 1, 'tip');
 
       // submit a withdrawal proof
@@ -416,7 +416,7 @@ module.exports = test('proveInvalidWitness', async t => {
         }));
         await t.wait(
             contract.commitRoot(
-                root2.properties.merkleTreeRoot.get(), 0, 0, combine(txs2),
+                root2.properties.merkleTreeRoot().get(), 0, 0, combine(txs2),
                 overrides),
             'valid submit', errors);
 

--- a/src/tests/proveMalformedBlock.js
+++ b/src/tests/proveMalformedBlock.js
@@ -1,5 +1,5 @@
 const { test, utils, overrides } = require('@fuel-js/environment');
-const { struct, chunk, combine } = require('@fuel-js/common/struct');
+const { struct, chunk, combine } = require('@fuel-js/struct');
 const { bytecode, abi, errors } = require('../builds/Fuel.json');
 const Proxy = require('../builds/Proxy.json');
 const { BlockHeader, RootHeader, Leaf,
@@ -53,7 +53,7 @@ module.exports = test('proveMalformedBlock', async t => { try {
         ...overrides,
         value: await contract.BOND_SIZE(),
       }), 'commit block', errors);
-      header.properties.ethereumBlockNumber.set(ctx.events[0].blockNumber);
+      header.properties.blockNumber().set(ctx.events[0].blockNumber);
       t.equalBig(await contract.blockTip(), 1, 'tip');
 
       // submit proof, but block is valid
@@ -150,7 +150,7 @@ module.exports = test('proveMalformedBlock', async t => { try {
       const maxLen = 57000;
       let randomSelectedLeaves = [];
       for (const leaf of randomLeaves) {
-        const len = leaf.properties.data.get().length
+        const len = leaf.properties.data().get().length
         if ((totalLen + len) <= maxLen) {
           randomSelectedLeaves.push(leaf);
           totalLen += len;

--- a/src/tests/verifyHeader.js
+++ b/src/tests/verifyHeader.js
@@ -1,5 +1,5 @@
 const { test, utils, overrides } = require('@fuel-js/environment');
-const { chunk, pack, combine } = require('@fuel-js/common/struct');
+const { chunk, pack, combine } = require('@fuel-js/struct');
 const { bytecode, abi, errors } = require('../builds/Fuel.json');
 const Proxy = require('../builds/Proxy.json');
 const ERC20 = require('../builds/ERC20.json');
@@ -96,7 +96,7 @@ module.exports = test('verifyHeader', async t => { try {
     }));
 
 
-    await t.wait(contract.commitRoot(root.properties.merkleTreeRoot.get(), 0, 0, combine(txs), overrides),
+    await t.wait(contract.commitRoot(root.properties.merkleTreeRoot().get(), 0, 0, combine(txs), overrides),
       'valid submit', errors);
     const header = (new BlockHeader({
       producer,
@@ -112,7 +112,7 @@ module.exports = test('verifyHeader', async t => { try {
       ...overrides,
       value: await contract.BOND_SIZE(),
     }), 'commit block', errors);
-    header.properties.ethereumBlockNumber.set(block.events[0].blockNumber);
+    header.properties.blockNumber().set(block.events[0].blockNumber);
     t.equalBig(await contract.blockTip(), 1, 'tip');
 
     // submit a withdrawal proof

--- a/src/tests/withdraw.js
+++ b/src/tests/withdraw.js
@@ -1,5 +1,5 @@
 const { test, utils, overrides } = require('@fuel-js/environment');
-const { chunk, pack, combine } = require('@fuel-js/common/struct');
+const { chunk, pack, combine } = require('@fuel-js/struct');
 const { bytecode, abi, errors } = require('../builds/Fuel.json');
 const Proxy = require('../builds/Proxy.json');
 const ERC20 = require('../builds/ERC20.json');
@@ -96,7 +96,7 @@ module.exports = test('withdraw', async t => { try {
     }));
 
 
-    await t.wait(contract.commitRoot(root.properties.merkleTreeRoot.get(), 0, 0, combine(txs), overrides),
+    await t.wait(contract.commitRoot(root.properties.merkleTreeRoot().get(), 0, 0, combine(txs), overrides),
       'valid submit', errors);
     const header = (new BlockHeader({
       producer,
@@ -112,7 +112,7 @@ module.exports = test('withdraw', async t => { try {
       ...overrides,
       value: await contract.BOND_SIZE(),
     }), 'commit block', errors);
-    header.properties.ethereumBlockNumber.set(block.events[0].blockNumber);
+    header.properties.blockNumber().set(block.events[0].blockNumber);
     t.equalBig(await contract.blockTip(), 1, 'tip');
 
     // submit a withdrawal proof


### PR DESCRIPTION
### Changes
- update all struct properties to new API: (e.g. `block.properties.height.get()` -> `block.properties.height().get()`)
- update ethereumBlockNumber -> blockNumber for consistency with new protocol lib 0.1.7

All tests pass on my end, all benchmarks work.